### PR TITLE
Remove alias "" from YouTube

### DIFF
--- a/src/commands/search/youtube.ts
+++ b/src/commands/search/youtube.ts
@@ -5,9 +5,7 @@ import { MessageEmbed } from 'discord.js'
 const YoutubeCommand: Command = {
     name: 'youtube',
     description: 'Watch Youtube in Discord',
-    aliases: [
-        ''
-    ],
+    aliases: [],
     guildOnly: false,
     ownerOnly: false,
     disabled: false,


### PR DESCRIPTION
YouTube had an alias of "" which means that it would also work with just the prefix :expressionless:
